### PR TITLE
Protection from recursive val

### DIFF
--- a/analyzer.go
+++ b/analyzer.go
@@ -137,6 +137,13 @@ func New(options ...Option) *Analyzer {
 		o.apply(a)
 	}
 	for _, v := range a.values {
+		if v.GetValue() == "" {
+			panic("Value's value missed")
+		}
+		if v.GetKey() == "" {
+			panic("Value's key missed")
+		}
+
 		err := v.Calculate(a.values)
 		if err != nil {
 			panic(err.Error())

--- a/analyzer.go
+++ b/analyzer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -54,6 +54,7 @@ func TestAnalyzer_YearRangeValue_ShouldWorkWithComplexVariables(t *testing.T) {
 	var vals, err = conf.GetValues()
 	require.NoError(t, err)
 	vals["my-val"] = &goheader.RegexpValue{
+		Key:      "my-val",
 		RawValue: "{{ year-range }} B",
 	}
 	var a = goheader.New(goheader.WithTemplate("A {{ my-val }}"), goheader.WithValues(vals))
@@ -65,6 +66,7 @@ func TestAnalyzer_YearRangeValue_CurrentYearOnly(t *testing.T) {
 	var vals, err = conf.GetValues()
 	require.NoError(t, err)
 	vals["current-year"] = &goheader.RegexpValue{
+		Key:      "current-year",
 		RawValue: "{{ year-range }} C",
 	}
 	var a = goheader.New(goheader.WithTemplate("A {{ current-year }}"), goheader.WithValues(vals))
@@ -76,6 +78,7 @@ func TestAnalyzer_Analyze1(t *testing.T) {
 		goheader.WithTemplate("A {{ YEAR }}\nB"),
 		goheader.WithValues(map[string]goheader.Value{
 			"YEAR": &goheader.ConstValue{
+				Key:      "YEAR",
 				RawValue: "2020",
 			},
 		}))
@@ -89,9 +92,11 @@ func TestAnalyzer_Analyze2(t *testing.T) {
 		goheader.WithTemplate("{{COPYRIGHT HOLDER}}TEXT"),
 		goheader.WithValues(map[string]goheader.Value{
 			"COPYRIGHT HOLDER": &goheader.RegexpValue{
+				Key:      "COPYRIGHT HOLDER",
 				RawValue: "(A {{ YEAR }}\n(.*)\n)+",
 			},
 			"YEAR": &goheader.ConstValue{
+				Key:      "YEAR",
 				RawValue: "2020",
 			},
 		}))
@@ -109,9 +114,11 @@ func TestAnalyzer_Analyze3(t *testing.T) {
 		goheader.WithTemplate("{{COPYRIGHT HOLDER}}TEXT"),
 		goheader.WithValues(map[string]goheader.Value{
 			"COPYRIGHT HOLDER": &goheader.RegexpValue{
+				Key:      "COPYRIGHT HOLDER",
 				RawValue: "(A {{ YEAR }}\n(.*)\n)+",
 			},
 			"YEAR": &goheader.ConstValue{
+				Key:      "YEAR",
 				RawValue: "2020",
 			},
 		}))
@@ -129,18 +136,23 @@ func TestAnalyzer_Analyze4(t *testing.T) {
 		goheader.WithTemplate("{{ A }}"),
 		goheader.WithValues(map[string]goheader.Value{
 			"A": &goheader.RegexpValue{
+				Key:      "A",
 				RawValue: "[{{ B }}{{ C }}]{{D}}",
 			},
 			"B": &goheader.ConstValue{
+				Key:      "B",
 				RawValue: "a-",
 			},
 			"C": &goheader.RegexpValue{
+				Key:      "C",
 				RawValue: "z",
 			},
 			"D": &goheader.ConstValue{
+				Key:      "D",
 				RawValue: "{{E}}",
 			},
 			"E": &goheader.ConstValue{
+				Key:      "E",
 				RawValue: "{7}",
 			},
 		}))
@@ -162,6 +174,20 @@ func TestAnalyzer_Analyze5(t *testing.T) {
 	require.Nil(t, a.Analyze(&goheader.Target{File: f, Path: p}))
 }
 
+func TestAnalyzer_Analyze6(t *testing.T) {
+	require.PanicsWithValue(t, goheader.ErrRecursiveValue.Error()+": SOME-VALUE", func() {
+		goheader.New(
+			goheader.WithTemplate("A {{ some-value }} B"),
+			goheader.WithValues(map[string]goheader.Value{
+				"SOME-VALUE": &goheader.ConstValue{
+					Key:      "SOME-VALUE",
+					RawValue: "{{ some-value }}",
+				},
+			}),
+		)
+	})
+}
+
 func TestREADME(t *testing.T) {
 	a := goheader.New(
 		goheader.WithTemplate(`{{ MY COMPANY }}
@@ -180,6 +206,7 @@ See the License for the specific language governing permissions and
 limitations under the License.`),
 		goheader.WithValues(map[string]goheader.Value{
 			"MY COMPANY": &goheader.ConstValue{
+				Key:      "MY COMPANY",
 				RawValue: "mycompany.com",
 			},
 		}))

--- a/cmd/go-header/main.go
+++ b/cmd/go-header/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/config.go
+++ b/config.go
@@ -28,11 +28,11 @@ import (
 
 // Configuration represents go-header linter setup parameters
 type Configuration struct {
-	// Values is map of values. Supports two types 'const` and `regexp`. Values can be used recursively.
-	Values map[string]map[string]string `yaml:"values"'`
+	// Values is map of values. Supports two types `const` and `regexp`. Values can be used recursively.
+	Values map[string]map[string]string `yaml:"values"`
 	// Template is template for checking. Uses values.
 	Template string `yaml:"template"`
-	// TemplatePath path to the template file. Useful if need to load the template from a specific file.
+	// TemplatePath path to the template file. Useful if needed to load the template from a specific file.
 	TemplatePath string `yaml:"template-path"`
 }
 
@@ -40,9 +40,11 @@ func (c *Configuration) builtInValues() map[string]Value {
 	var result = make(map[string]Value)
 	year := fmt.Sprint(time.Now().Year())
 	result["year-range"] = &RegexpValue{
+		Key:      "year-range",
 		RawValue: strings.ReplaceAll(`((20\d\d\-YEAR)|(YEAR))`, "YEAR", year),
 	}
 	result["year"] = &ConstValue{
+		Key:      "year",
 		RawValue: year,
 	}
 	return result
@@ -50,16 +52,16 @@ func (c *Configuration) builtInValues() map[string]Value {
 
 func (c *Configuration) GetValues() (map[string]Value, error) {
 	var result = c.builtInValues()
-	createConst := func(raw string) Value {
-		return &ConstValue{RawValue: raw}
+	createConst := func(k, raw string) Value {
+		return &ConstValue{Key: k, RawValue: raw}
 	}
-	createRegexp := func(raw string) Value {
-		return &RegexpValue{RawValue: raw}
+	createRegexp := func(k, raw string) Value {
+		return &RegexpValue{Key: k, RawValue: raw}
 	}
-	appendValues := func(m map[string]string, create func(string) Value) {
+	appendValues := func(m map[string]string, create func(string, string) Value) {
 		for k, v := range m {
 			key := strings.ToLower(k)
-			result[key] = create(v)
+			result[key] = create(key, v)
 		}
 	}
 	for k, v := range c.Values {

--- a/config.go
+++ b/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/issue.go
+++ b/issue.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/location.go
+++ b/location.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/option.go
+++ b/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/value.go
+++ b/value.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/value.go
+++ b/value.go
@@ -23,9 +23,12 @@ import (
 	"strings"
 )
 
+var ErrRecursiveValue = errors.New("recursive value")
+
 type Calculable interface {
 	Calculate(map[string]Value) error
-	Get() string
+	GetKey() string
+	GetValue() string
 }
 
 type Value interface {
@@ -35,7 +38,7 @@ type Value interface {
 
 func calculateValue(calculable Calculable, values map[string]Value) (string, error) {
 	sb := strings.Builder{}
-	r := calculable.Get()
+	r := calculable.GetValue()
 	var endIndex int
 	var startIndex int
 	for startIndex = strings.Index(r, "{{"); startIndex >= 0; startIndex = strings.Index(r, "{{") {
@@ -44,12 +47,15 @@ func calculateValue(calculable Calculable, values map[string]Value) (string, err
 		if endIndex < 0 {
 			return "", errors.New("missed value ending")
 		}
-		subVal := strings.ToLower(strings.TrimSpace(r[startIndex+2 : endIndex]))
+		subVal := normalize(r[startIndex+2 : endIndex])
 		if val := values[subVal]; val != nil {
+			if k := calculable.GetKey(); normalize(k) == subVal {
+				return "", fmt.Errorf("%w: %v", ErrRecursiveValue, k)
+			}
 			if err := val.Calculate(values); err != nil {
 				return "", err
 			}
-			sb.WriteString(val.Get())
+			sb.WriteString(val.GetValue())
 		} else {
 			return "", fmt.Errorf("unknown value name %v", subVal)
 		}
@@ -60,7 +66,12 @@ func calculateValue(calculable Calculable, values map[string]Value) (string, err
 	return sb.String(), nil
 }
 
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
 type ConstValue struct {
+	Key      string
 	RawValue string
 }
 
@@ -73,20 +84,24 @@ func (c *ConstValue) Calculate(values map[string]Value) error {
 	return nil
 }
 
-func (c *ConstValue) Get() string {
+func (c *ConstValue) GetKey() string {
+	return c.Key
+}
+
+func (c *ConstValue) GetValue() string {
 	return c.RawValue
 }
 
 func (c *ConstValue) Read(s *Reader) Issue {
 	l := s.Location()
 	p := s.Position()
-	for _, ch := range c.Get() {
+	for _, ch := range c.GetValue() {
 		if ch != s.Peek() {
 			s.SetPosition(p)
 			f := s.ReadWhile(func(r rune) bool {
 				return r != '\n'
 			})
-			return NewIssueWithLocation(fmt.Sprintf("Expected:%v, Actual: %v", c.Get(), f), l)
+			return NewIssueWithLocation(fmt.Sprintf("Expected:%v, Actual: %v", c.GetValue(), f), l)
 		}
 		s.Next()
 	}
@@ -94,6 +109,7 @@ func (c *ConstValue) Read(s *Reader) Issue {
 }
 
 type RegexpValue struct {
+	Key      string
 	RawValue string
 }
 
@@ -106,13 +122,17 @@ func (r *RegexpValue) Calculate(values map[string]Value) error {
 	return nil
 }
 
-func (r *RegexpValue) Get() string {
+func (c *RegexpValue) GetKey() string {
+	return c.Key
+}
+
+func (r *RegexpValue) GetValue() string {
 	return r.RawValue
 }
 
 func (r *RegexpValue) Read(s *Reader) Issue {
 	l := s.Location()
-	p := regexp.MustCompile(r.Get())
+	p := regexp.MustCompile(r.GetValue())
 	pos := s.Position()
 	str := s.Finish()
 	s.SetPosition(pos)

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 func Value() string {
-	return "v0.4.3"
+	return "v0.4.4"
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 Denis Tingaikin
+// Copyright (c) 2020-2023 Denis Tingaikin
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
Test:
```go
goheader.New(
	goheader.WithTemplate("A {{ some-value }} B"),
	goheader.WithValues(map[string]goheader.Value{
		"SOME-VALUE": &goheader.ConstValue{
			Key:      "SOME-VALUE",
			RawValue: "{{ some-value }}",
		},
	}),
)
```

Output:
<details>

```console
=== RUN   TestAnalyzer_Analyze6
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x14020160390 stack=[0x14020160000, 0x14040160000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x1044fc0b0?, 0x1046b5780?})
	/usr/local/go/src/runtime/panic.go:1047 +0x40 fp=0x16ba86dd0 sp=0x16ba86da0 pc=0x1043ab9d0
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:1105 +0x460 fp=0x16ba86f80 sp=0x16ba86dd0 pc=0x1043c5690
runtime.morestack()
	/usr/local/go/src/runtime/asm_arm64.s:316 +0x70 fp=0x16ba86f80 sp=0x16ba86f80 pc=0x1043dc460

goroutine 6 [running]:
strings.Index({0x1044fcb06, 0x10}, {0x1044f90df, 0x2})
	/usr/local/go/src/strings/strings.go:1178 +0x554 fp=0x14020160390 sp=0x14020160390 pc=0x10442b784
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:41 +0x54 fp=0x14020160470 sp=0x14020160390 pc=0x10449d354
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201604a0 sp=0x14020160470 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160580 sp=0x140201604a0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201605b0 sp=0x14020160580 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160690 sp=0x140201605b0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201606c0 sp=0x14020160690 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201607a0 sp=0x140201606c0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201607d0 sp=0x140201607a0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201608b0 sp=0x140201607d0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201608e0 sp=0x140201608b0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201609c0 sp=0x140201608e0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201609f0 sp=0x140201609c0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160ad0 sp=0x140201609f0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020160b00 sp=0x14020160ad0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160be0 sp=0x14020160b00 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020160c10 sp=0x14020160be0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160cf0 sp=0x14020160c10 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020160d20 sp=0x14020160cf0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160e00 sp=0x14020160d20 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020160e30 sp=0x14020160e00 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020160f10 sp=0x14020160e30 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020160f40 sp=0x14020160f10 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161020 sp=0x14020160f40 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161050 sp=0x14020161020 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161130 sp=0x14020161050 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161160 sp=0x14020161130 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161240 sp=0x14020161160 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161270 sp=0x14020161240 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161350 sp=0x14020161270 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161380 sp=0x14020161350 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161460 sp=0x14020161380 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161490 sp=0x14020161460 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161570 sp=0x14020161490 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201615a0 sp=0x14020161570 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161680 sp=0x140201615a0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201616b0 sp=0x14020161680 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161790 sp=0x140201616b0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201617c0 sp=0x14020161790 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201618a0 sp=0x140201617c0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201618d0 sp=0x140201618a0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201619b0 sp=0x140201618d0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201619e0 sp=0x140201619b0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161ac0 sp=0x140201619e0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161af0 sp=0x14020161ac0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161bd0 sp=0x14020161af0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161c00 sp=0x14020161bd0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161ce0 sp=0x14020161c00 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161d10 sp=0x14020161ce0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161df0 sp=0x14020161d10 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161e20 sp=0x14020161df0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020161f00 sp=0x14020161e20 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020161f30 sp=0x14020161f00 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162010 sp=0x14020161f30 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162040 sp=0x14020162010 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162120 sp=0x14020162040 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162150 sp=0x14020162120 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162230 sp=0x14020162150 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162260 sp=0x14020162230 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162340 sp=0x14020162260 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162370 sp=0x14020162340 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162450 sp=0x14020162370 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162480 sp=0x14020162450 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162560 sp=0x14020162480 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162590 sp=0x14020162560 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162670 sp=0x14020162590 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201626a0 sp=0x14020162670 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162780 sp=0x140201626a0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201627b0 sp=0x14020162780 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162890 sp=0x140201627b0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201628c0 sp=0x14020162890 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x140201629a0 sp=0x140201628c0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201629d0 sp=0x140201629a0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162ab0 sp=0x140201629d0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162ae0 sp=0x14020162ab0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162bc0 sp=0x14020162ae0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162bf0 sp=0x14020162bc0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162cd0 sp=0x14020162bf0 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162d00 sp=0x14020162cd0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162de0 sp=0x14020162d00 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162e10 sp=0x14020162de0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020162ef0 sp=0x14020162e10 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020162f20 sp=0x14020162ef0 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163000 sp=0x14020162f20 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163030 sp=0x14020163000 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163110 sp=0x14020163030 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163140 sp=0x14020163110 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163220 sp=0x14020163140 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163250 sp=0x14020163220 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163330 sp=0x14020163250 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163360 sp=0x14020163330 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163440 sp=0x14020163360 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163470 sp=0x14020163440 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163550 sp=0x14020163470 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163580 sp=0x14020163550 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163660 sp=0x14020163580 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x14020163690 sp=0x14020163660 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163770 sp=0x14020163690 pc=0x10449d508
github.com/denis-tingaikin/go-header.(*ConstValue).Calculate(0x1400005c530, 0x14000075290?)
	/Users/anthony/go-header/value.go:68 +0x30 fp=0x140201637a0 sp=0x14020163770 pc=0x10449d820
github.com/denis-tingaikin/go-header.calculateValue({0x1045b2f18?, 0x1400005c530?}, 0x0?)
	/Users/anthony/go-header/value.go:49 +0x208 fp=0x14020163880 sp=0x140201637a0 pc=0x10449d508
...additional frames elided...
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1629 +0x370

goroutine 1 [chan receive]:
runtime.gopark(0x1400000e090?, 0x0?, 0xf8?, 0xd9?, 0x104383ecc?)
	/usr/local/go/src/runtime/proc.go:381 +0xe0 fp=0x1400012d970 sp=0x1400012d950 pc=0x1043ae3a0
runtime.chanrecv(0x14000022690, 0x1400012da7f, 0x1)
	/usr/local/go/src/runtime/chan.go:583 +0x468 fp=0x1400012da00 sp=0x1400012d970 pc=0x10437d638
runtime.chanrecv1(0x1046e6360?, 0x10456eec0?)
	/usr/local/go/src/runtime/chan.go:442 +0x14 fp=0x1400012da30 sp=0x1400012da00 pc=0x10437d1c4
testing.(*T).Run(0x14000003d40, {0x1044fe4be?, 0x34c2aaf2f4e7a?}, 0x1045b1370)
	/usr/local/go/src/testing/testing.go:1630 +0x384 fp=0x1400012daf0 sp=0x1400012da30 pc=0x1044410b4
testing.runTests.func1(0x14000075200?)
	/usr/local/go/src/testing/testing.go:2036 +0x48 fp=0x1400012db40 sp=0x1400012daf0 pc=0x104442e98
testing.tRunner(0x14000003d40, 0x1400012dc68)
	/usr/local/go/src/testing/testing.go:1576 +0x104 fp=0x1400012db90 sp=0x1400012db40 pc=0x1044403a4
testing.runTests(0x14000103040?, {0x1046e1460, 0x9, 0x9}, {0x14000024b40?, 0x40?, 0x0?})
	/usr/local/go/src/testing/testing.go:2034 +0x3c4 fp=0x1400012dc90 sp=0x1400012db90 pc=0x104442d94
testing.(*M).Run(0x14000103040)
	/usr/local/go/src/testing/testing.go:1906 +0x530 fp=0x1400012dee0 sp=0x1400012dc90 pc=0x104441aa0
main.main()
	_testmain.go:65 +0x1a8 fp=0x1400012df70 sp=0x1400012dee0 pc=0x1044f8bb8
runtime.main()
	/usr/local/go/src/runtime/proc.go:250 +0x200 fp=0x1400012dfd0 sp=0x1400012df70 pc=0x1043adf90
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1172 +0x4 fp=0x1400012dfd0 sp=0x1400012dfd0 pc=0x1043de7f4

goroutine 2 [force gc (idle)]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/usr/local/go/src/runtime/proc.go:381 +0xe0 fp=0x14000046fa0 sp=0x14000046f80 pc=0x1043ae3a0
runtime.goparkunlock(...)
	/usr/local/go/src/runtime/proc.go:387
runtime.forcegchelper()
	/usr/local/go/src/runtime/proc.go:305 +0xb0 fp=0x14000046fd0 sp=0x14000046fa0 pc=0x1043ae1f0
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1172 +0x4 fp=0x14000046fd0 sp=0x14000046fd0 pc=0x1043de7f4
created by runtime.init.6
	/usr/local/go/src/runtime/proc.go:293 +0x24

goroutine 3 [GC sweep wait]:
runtime.gopark(0x0?, 0x0?, 0x0?, 0x0?, 0x0?)
	/usr/local/go/src/runtime/proc.go:381 +0xe0 fp=0x14000047760 sp=0x14000047740 pc=0x1043ae3a0
runtime.goparkunlock(...)
	/usr/local/go/src/runtime/proc.go:387
runtime.bgsweep(0x0?)
	/usr/local/go/src/runtime/mgcsweep.go:278 +0x98 fp=0x140000477b0 sp=0x14000047760 pc=0x104399b98
runtime.gcenable.func1()
	/usr/local/go/src/runtime/mgc.go:178 +0x28 fp=0x140000477d0 sp=0x140000477b0 pc=0x10438ebf8
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1172 +0x4 fp=0x140000477d0 sp=0x140000477d0 pc=0x1043de7f4
created by runtime.gcenable
	/usr/local/go/src/runtime/mgc.go:178 +0x6c

goroutine 4 [GC scavenge wait]:
runtime.gopark(0x14000022070?, 0x104551638?, 0x1?, 0x0?, 0x0?)
	/usr/local/go/src/runtime/proc.go:381 +0xe0 fp=0x14000047f50 sp=0x14000047f30 pc=0x1043ae3a0
runtime.goparkunlock(...)
	/usr/local/go/src/runtime/proc.go:387
runtime.(*scavengerState).park(0x1046e6800)
	/usr/local/go/src/runtime/mgcscavenge.go:400 +0x5c fp=0x14000047f80 sp=0x14000047f50 pc=0x104397acc
runtime.bgscavenge(0x0?)
	/usr/local/go/src/runtime/mgcscavenge.go:628 +0x44 fp=0x14000047fb0 sp=0x14000047f80 pc=0x104398024
runtime.gcenable.func2()
	/usr/local/go/src/runtime/mgc.go:179 +0x28 fp=0x14000047fd0 sp=0x14000047fb0 pc=0x10438eb98
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1172 +0x4 fp=0x14000047fd0 sp=0x14000047fd0 pc=0x1043de7f4
created by runtime.gcenable
	/usr/local/go/src/runtime/mgc.go:179 +0xac

goroutine 5 [finalizer wait]:
runtime.gopark(0x140000465a8?, 0x6000010438cba8?, 0x88?, 0xeb?, 0x1?)
	/usr/local/go/src/runtime/proc.go:381 +0xe0 fp=0x14000046580 sp=0x14000046560 pc=0x1043ae3a0
runtime.runfinq()
	/usr/local/go/src/runtime/mfinal.go:193 +0x100 fp=0x140000467d0 sp=0x14000046580 pc=0x10438dcc0
runtime.goexit()
	/usr/local/go/src/runtime/asm_arm64.s:1172 +0x4 fp=0x140000467d0 sp=0x140000467d0 pc=0x1043de7f4
created by runtime.createfing
	/usr/local/go/src/runtime/mfinal.go:163 +0x80


Process finished with the exit code 1
```

<details>