### PR TITLE
fix install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Go source code linter providing checks for license headers.
 
 ## Installation
 
-For installation you can simply use `go get`.
+For installation you can simply use `go install`.
 
 ```bash
-go install github.com/denis-tingaikin/go-header/cmd/go-header
+go install github.com/denis-tingaikin/go-header/cmd/go-header@latest
 ```
 
 ## Configuration


### PR DESCRIPTION
The PR fixes installation command in README.

Now, we have an error:
```sh
❯ go version
go version go1.24.0 darwin/arm64

❯ go install github.com/denis-tingaikin/go-header/cmd/go-header@latest
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/denis-tingaikin/go-header/cmd/go-header@latest' to install the latest version
```

After:
```sh
❯ go install github.com/denis-tingaikin/go-header/cmd/go-header@latest
```